### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,8 @@
 name: Build and Deploy
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]
@@ -41,6 +44,9 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      pages: write
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/P3klgh/Graduation-Portal/security/code-scanning/2](https://github.com/P3klgh/Graduation-Portal/security/code-scanning/2)

To fix the issue, add a `permissions` block to the root of the workflow and/or individual jobs to explicitly define the least privileges required. For this workflow:
- At the root level, set `contents: read` to limit repository access to read-only.
- For the `deploy` job, add `contents: read` and `pages: write` (if deploying to GitHub Pages) or other specific permissions required for deployment.

This ensures that the `GITHUB_TOKEN` has only the necessary permissions for each job, reducing the risk of misuse.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
